### PR TITLE
Reduce required memory

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -10,4 +10,4 @@ applications:
   command: npm start
   path: .
   instances: 2
-  memory: 512MB
+  memory: 256MB


### PR DESCRIPTION
Reduce memory to 256MB in order to fit within the
free tier allowance.